### PR TITLE
Create a test case around Sidekiq 7.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
           - '6.0'
           - '6.4'
           - '6.5'
+          - '7.1'
 
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/sidekiq_${{ matrix.sidekiq }}.gemfile

--- a/gemfiles/sidekiq_7.1.gemfile
+++ b/gemfiles/sidekiq_7.1.gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in logcraft-sidekiq.gemspec
+gemspec path: '..'
+
+group :test do
+  gem 'sidekiq', '~> 7.1.0'
+end

--- a/logcraft-sidekiq.gemspec
+++ b/logcraft-sidekiq.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "logcraft"
-  spec.add_dependency "sidekiq", "~> 6.0"
+  spec.add_dependency "sidekiq", ">= 6.0", "< 8.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", ">= 12.0"


### PR DESCRIPTION
## Context

As per https://github.com/zormandi/logcraft-sidekiq/issues/1 we're keen to look at using this library against Sidekiq 7.

## What's changed?
- Add Sidekiq 7.1 to the test matrix.
- Loosen the gemspec version so it works with either 6 or 7.