### PR TITLE
Accept config param for error handlers

### DIFF
--- a/lib/logcraft/sidekiq/error_logger.rb
+++ b/lib/logcraft/sidekiq/error_logger.rb
@@ -5,7 +5,7 @@ module Logcraft
     class ErrorLogger
       include Logcraft::LogContextHelper
 
-      def call(error, context)
+      def call(error, context, config = nil)
         within_log_context(JobContext.from_job_hash(context[:job])) do
           ::Sidekiq.logger.warn error
         end


### PR DESCRIPTION
Sidekiq introduced a deprecation warning in sidekiq/sideki#6051 for an upcoming change in Sidekiq 8.0.

Configs are no longer included in the context param, but are instead provided by a new dedicated param.

In an attempt to maintain backwards compatibility, I've opted to make this third param optional with a default of `nil`, which *should* work on older versions of sidekiq (which do not have logical checks around arity of the handler and simply call `handler.call(ex, ctx)` while addressing the deprecation warning on newer versions of Sidekiq.