### PR TITLE
Do not assume a JobLogger receives a logger

### DIFF
--- a/lib/logcraft/sidekiq/job_logger.rb
+++ b/lib/logcraft/sidekiq/job_logger.rb
@@ -6,7 +6,7 @@ module Logcraft
       include Logcraft::LogContextHelper
 
       def initialize(config_or_logger = ::Sidekiq.logger)
-        @logger = if config_or_logger.kind_of?(::Sidekiq::Config)
+        @logger = if defined?(::Sidekiq::Config) && config_or_logger.kind_of?(::Sidekiq::Config)
                     config_or_logger.logger
                   else
                     config_or_logger

--- a/lib/logcraft/sidekiq/job_logger.rb
+++ b/lib/logcraft/sidekiq/job_logger.rb
@@ -5,8 +5,12 @@ module Logcraft
     class JobLogger
       include Logcraft::LogContextHelper
 
-      def initialize(logger = ::Sidekiq.logger)
-        @logger = logger
+      def initialize(config_or_logger = ::Sidekiq.logger)
+        @logger = if config_or_logger.kind_of?(::Sidekiq::Config)
+                    config_or_logger.logger
+                  else
+                    config_or_logger
+                  end
       end
 
       def call(job_hash, _queue)


### PR DESCRIPTION
In sidekiq/sidekiq#6200, the constructor for JobLogger was changed to accept an entire `Sidekiq::Config` rather than a logger.

To maintain compatibility with previous versions of Sidekiq, the constructor for Logcraft's Sidekiq::JobLogger has been changed to handle both cases by checking the type of the argument before assigning the logger.